### PR TITLE
Add multi-track ad insertion for HLS and DASH

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,11 +275,16 @@ cargo clippy -- -D warnings
 - [x] DASH manifest handler and routes
 - [x] DASH demo endpoint
 
-### Phase 3: Advanced
+### Phase 3: Multi-Track & Session Hardening
+
+- [ ] Multi-track ad insertion (separate audio/video renditions with different segment lengths)
+- [ ] Distributed session store (Valkey/Redis for multi-instance consistency)
+- [x] Ad tracking and beaconing
+
+### Phase 4: Advanced
 
 - [ ] Low-latency HLS (LL-HLS)
 - [ ] Server-Guided Ad Insertion (SGAI)
-- [x] Ad tracking and beaconing
 - [ ] Per-viewer manifest personalization
 
 ---

--- a/src/server/handlers/demo.rs
+++ b/src/server/handlers/demo.rs
@@ -106,6 +106,11 @@ pub async fn serve_demo_manifest() -> Response {
         <SegmentTemplate media="url_$Number$/193039199_mp4_h264_aac_hd_7.ts" timescale="1" duration="10" startNumber="462"/>
       </Representation>
     </AdaptationSet>
+    <AdaptationSet id="2" contentType="audio" mimeType="audio/mp4" lang="en">
+      <Representation id="audio" bandwidth="128000" codecs="mp4a.40.2">
+        <SegmentTemplate media="url_$Number$/193039199_mp4_h264_aac_hd_7.ts" timescale="1" duration="10" startNumber="462"/>
+      </Representation>
+    </AdaptationSet>
     <EventStream schemeIdUri="urn:scte:scte35:2013:xml" timescale="1">
       <Event presentationTime="50" duration="30" id="ad-1">
         <scte35:SpliceInfoSection xmlns:scte35="http://www.scte.org/schemas/35/2016">
@@ -123,10 +128,15 @@ pub async fn serve_demo_manifest() -> Response {
         <SegmentTemplate media="url_$Number$/193039199_mp4_h264_aac_hd_7.ts" timescale="1" duration="10" startNumber="468"/>
       </Representation>
     </AdaptationSet>
+    <AdaptationSet id="2" contentType="audio" mimeType="audio/mp4" lang="en">
+      <Representation id="audio" bandwidth="128000" codecs="mp4a.40.2">
+        <SegmentTemplate media="url_$Number$/193039199_mp4_h264_aac_hd_7.ts" timescale="1" duration="10" startNumber="468"/>
+      </Representation>
+    </AdaptationSet>
   </Period>
 </MPD>"#;
 
-    info!("Demo manifest: 2 content periods, 1 SCTE-35 signal (30s ad break at 50s)");
+    info!("Demo manifest: 2 content periods (video+audio), 1 SCTE-35 signal (30s ad break at 50s)");
 
     (
         StatusCode::OK,


### PR DESCRIPTION
## Summary
- HLS master playlist rewrites now append `&track=audio|subtitles|video` for alternative media URIs, enabling track-aware ad insertion
- Playlist handler routes each track type correctly: subtitles skip ad insertion, audio uses muxed ad segments, video gets full pipeline
- DASH ad Periods mirror content Period's AdaptationSet structure (video + audio) with bandwidth copied from source representations
- Track type validation normalizes unknown values to `"video"` (code review fix)
- Demo manifest updated with audio AdaptationSets for testing

## Test plan
- [x] All 92 tests pass (87 unit + 5 E2E)
- [x] 0 clippy warnings
- [x] HLS: track param correctly appended for audio, subtitles; not for video variants
- [x] DASH: ad Period mirrors video+audio AdaptationSets with correct bandwidth/lang
- [x] Fallback: legacy content without AdaptationSets still works (backward compat)
- [ ] Manual test with multi-track HLS stream
- [ ] Manual test with multi-track DASH stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)