### PR TITLE
feat: distributed session store with Valkey backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -45,6 +45,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
+name = "arc-swap"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9f3647c145568cec02c42054e07bdf9a5a698e15b466fb2341bfc393cd24aa5"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +137,15 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "backon"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cffb0e931875b666fc4fcb20fee52e9bbd1ef836fd9e9e04ec21555f9f85f7ef"
+dependencies = [
+ "fastrand",
 ]
 
 [[package]]
@@ -263,6 +281,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -898,7 +930,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.1",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1309,10 +1341,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -1607,6 +1658,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis"
+version = "0.29.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc42f3a12fd4408ce64d8efef67048a924e543bd35c6591c0447fda9054695f"
+dependencies = [
+ "arc-swap",
+ "backon",
+ "bytes",
+ "combine",
+ "futures-channel",
+ "futures-util",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,6 +1805,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "quick-xml",
+ "redis",
  "reqwest",
  "serde",
  "serde_json",
@@ -1994,6 +2070,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2034,6 +2116,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -2251,7 +2343,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.1",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,10 @@ name = "ritcher"
 version = "0.1.0"
 edition = "2024"
 
+[features]
+default = []
+valkey = ["redis"]
+
 [dependencies]
 axum = "0.8.6"
 tokio = { version = "1.42.0", features = ["full"] }
@@ -19,6 +23,7 @@ quick-xml = "0.37"
 dash-mpd = { version = "0.17", default-features = false }
 metrics = "0.24"
 metrics-exporter-prometheus = "0.16"
+redis = { version = "0.29", features = ["tokio-comp", "connection-manager"], optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/src/server/handlers/health.rs
+++ b/src/server/handlers/health.rs
@@ -20,7 +20,7 @@ pub async fn health_check(State(state): State<AppState>) -> impl IntoResponse {
     Json(HealthResponse {
         status: "ok",
         version: VERSION,
-        active_sessions: state.sessions.session_count(),
+        active_sessions: state.sessions.session_count().await,
         uptime_seconds: uptime,
     })
 }

--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -1,80 +1,291 @@
 use dashmap::DashMap;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 
+#[cfg(feature = "valkey")]
+use tracing::{error, info};
+
+#[cfg(feature = "valkey")]
+use redis::aio::ConnectionManager;
+
 /// Session data stored for each active session
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Session {
     pub session_id: String,
     pub origin_url: String,
+    #[serde(with = "epoch_secs")]
     pub created_at: SystemTime,
+    #[serde(with = "epoch_secs")]
     pub last_accessed: SystemTime,
 }
 
-/// Session manager using DashMap for concurrent access
+/// Serde helper: SystemTime ↔ u64 epoch seconds
+mod epoch_secs {
+    use serde::{Deserialize, Deserializer, Serializer};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    pub fn serialize<S>(time: &SystemTime, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let secs = time
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+        serializer.serialize_u64(secs)
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<SystemTime, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let secs = u64::deserialize(deserializer)?;
+        Ok(UNIX_EPOCH + Duration::from_secs(secs))
+    }
+}
+
+/// Internal storage backend
+#[derive(Clone)]
+enum Backend {
+    Memory {
+        sessions: Arc<DashMap<String, Session>>,
+    },
+    #[cfg(feature = "valkey")]
+    Valkey {
+        conn: ConnectionManager,
+        key_prefix: String,
+    },
+}
+
+/// Session manager — same public API regardless of backend
 #[derive(Clone)]
 pub struct SessionManager {
-    sessions: Arc<DashMap<String, Session>>,
+    backend: Backend,
     ttl: Duration,
 }
 
 impl SessionManager {
-    /// Create a new SessionManager with specified TTL
-    pub fn new(ttl: Duration) -> Self {
+    /// Create an in-memory session manager (default)
+    pub fn new_memory(ttl: Duration) -> Self {
         Self {
-            sessions: Arc::new(DashMap::new()),
+            backend: Backend::Memory {
+                sessions: Arc::new(DashMap::new()),
+            },
             ttl,
         }
     }
 
+    /// Create a Valkey-backed session manager
+    #[cfg(feature = "valkey")]
+    pub async fn new_valkey(url: &str, ttl: Duration) -> Result<Self, redis::RedisError> {
+        let client = redis::Client::open(url)?;
+        let conn = ConnectionManager::new(client).await?;
+        info!("Connected to Valkey at {}", url);
+        Ok(Self {
+            backend: Backend::Valkey {
+                conn,
+                key_prefix: "ritcher:session".to_string(),
+            },
+            ttl,
+        })
+    }
+
     /// Get or create a session
-    pub fn get_or_create(&self, session_id: String, origin_url: String) -> Session {
-        self.sessions
-            .entry(session_id.clone())
-            .or_insert_with(|| {
+    pub async fn get_or_create(&self, session_id: String, origin_url: String) -> Session {
+        match &self.backend {
+            Backend::Memory { sessions } => sessions
+                .entry(session_id.clone())
+                .or_insert_with(|| {
+                    let now = SystemTime::now();
+                    Session {
+                        session_id: session_id.clone(),
+                        origin_url,
+                        created_at: now,
+                        last_accessed: now,
+                    }
+                })
+                .clone(),
+            #[cfg(feature = "valkey")]
+            Backend::Valkey { conn, key_prefix } => {
+                let key = format!("{}:{}", key_prefix, session_id);
+                let mut conn = conn.clone();
+                // Try to get existing session
+                if let Ok(Some(json)) = redis::cmd("GET")
+                    .arg(&key)
+                    .query_async::<Option<String>>(&mut conn)
+                    .await
+                {
+                    if let Ok(session) = serde_json::from_str::<Session>(&json) {
+                        return session;
+                    }
+                }
+                // Create new session
                 let now = SystemTime::now();
-                Session {
+                let session = Session {
                     session_id: session_id.clone(),
                     origin_url,
                     created_at: now,
                     last_accessed: now,
+                };
+                if let Ok(json) = serde_json::to_string(&session) {
+                    let ttl_secs = self.ttl.as_secs();
+                    if let Err(e) = redis::cmd("SET")
+                        .arg(&key)
+                        .arg(&json)
+                        .arg("EX")
+                        .arg(ttl_secs)
+                        .query_async::<()>(&mut conn)
+                        .await
+                    {
+                        error!("Failed to store session in Valkey: {}", e);
+                    }
                 }
-            })
-            .clone()
+                session
+            }
+        }
     }
 
     /// Update last accessed time for a session
-    pub fn touch(&self, session_id: &str) {
-        if let Some(mut session) = self.sessions.get_mut(session_id) {
-            session.last_accessed = SystemTime::now();
+    pub async fn touch(&self, session_id: &str) {
+        match &self.backend {
+            Backend::Memory { sessions } => {
+                if let Some(mut session) = sessions.get_mut(session_id) {
+                    session.last_accessed = SystemTime::now();
+                }
+            }
+            #[cfg(feature = "valkey")]
+            Backend::Valkey { conn, key_prefix } => {
+                let key = format!("{}:{}", key_prefix, session_id);
+                let mut conn = conn.clone();
+                let json: Option<String> =
+                    match redis::cmd("GET").arg(&key).query_async(&mut conn).await {
+                        Ok(v) => v,
+                        Err(e) => {
+                            error!("Valkey GET failed in touch: {}", e);
+                            return;
+                        }
+                    };
+                if let Some(json) = json {
+                    if let Ok(mut session) = serde_json::from_str::<Session>(&json) {
+                        session.last_accessed = SystemTime::now();
+                        if let Ok(updated) = serde_json::to_string(&session) {
+                            let ttl_secs = self.ttl.as_secs();
+                            if let Err(e) = redis::cmd("SET")
+                                .arg(&key)
+                                .arg(&updated)
+                                .arg("EX")
+                                .arg(ttl_secs)
+                                .query_async::<()>(&mut conn)
+                                .await
+                            {
+                                error!("Valkey SET failed in touch: {}", e);
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 
     /// Get a session by ID
-    pub fn get(&self, session_id: &str) -> Option<Session> {
-        self.sessions.get(session_id).map(|s| s.clone())
+    pub async fn get(&self, session_id: &str) -> Option<Session> {
+        match &self.backend {
+            Backend::Memory { sessions } => sessions.get(session_id).map(|s| s.clone()),
+            #[cfg(feature = "valkey")]
+            Backend::Valkey { conn, key_prefix } => {
+                let key = format!("{}:{}", key_prefix, session_id);
+                let mut conn = conn.clone();
+                match redis::cmd("GET")
+                    .arg(&key)
+                    .query_async::<Option<String>>(&mut conn)
+                    .await
+                {
+                    Ok(Some(json)) => serde_json::from_str(&json).ok(),
+                    Ok(None) => None,
+                    Err(e) => {
+                        error!("Valkey GET failed: {}", e);
+                        None
+                    }
+                }
+            }
+        }
     }
 
-    /// Remove expired sessions (TTL cleanup)
-    pub fn cleanup_expired(&self) {
-        let now = SystemTime::now();
-        self.sessions.retain(|_, session| {
-            if let Ok(elapsed) = now.duration_since(session.last_accessed) {
-                elapsed < self.ttl
-            } else {
-                true // Keep if we can't determine elapsed time
+    /// Remove expired sessions (no-op for Valkey — TTL is native)
+    pub async fn cleanup_expired(&self) {
+        match &self.backend {
+            Backend::Memory { sessions } => {
+                let now = SystemTime::now();
+                sessions.retain(|_, session| {
+                    if let Ok(elapsed) = now.duration_since(session.last_accessed) {
+                        elapsed < self.ttl
+                    } else {
+                        true
+                    }
+                });
             }
-        });
+            #[cfg(feature = "valkey")]
+            Backend::Valkey { .. } => {
+                // Valkey handles TTL natively via EXPIRE — nothing to do
+            }
+        }
     }
 
     /// Get the count of active sessions
-    pub fn session_count(&self) -> usize {
-        self.sessions.len()
+    pub async fn session_count(&self) -> usize {
+        match &self.backend {
+            Backend::Memory { sessions } => sessions.len(),
+            #[cfg(feature = "valkey")]
+            Backend::Valkey { conn, key_prefix } => {
+                let pattern = format!("{}:*", key_prefix);
+                let mut conn = conn.clone();
+                // NOTE: KEYS is O(N) — acceptable for health endpoint at current scale.
+                // Replace with SCAN or atomic counter if session volume exceeds ~10k.
+                match redis::cmd("KEYS")
+                    .arg(&pattern)
+                    .query_async::<Vec<String>>(&mut conn)
+                    .await
+                {
+                    Ok(keys) => keys.len(),
+                    Err(e) => {
+                        error!("Valkey KEYS failed in session_count: {}", e);
+                        0
+                    }
+                }
+            }
+        }
     }
 
     /// Remove a specific session
-    pub fn remove(&self, session_id: &str) -> Option<Session> {
-        self.sessions.remove(session_id).map(|(_, session)| session)
+    pub async fn remove(&self, session_id: &str) -> Option<Session> {
+        match &self.backend {
+            Backend::Memory { sessions } => sessions.remove(session_id).map(|(_, session)| session),
+            #[cfg(feature = "valkey")]
+            Backend::Valkey { conn, key_prefix } => {
+                let key = format!("{}:{}", key_prefix, session_id);
+                let mut conn = conn.clone();
+                // GET then DEL
+                let json: Option<String> =
+                    match redis::cmd("GET").arg(&key).query_async(&mut conn).await {
+                        Ok(v) => v,
+                        Err(e) => {
+                            error!("Valkey GET failed in remove: {}", e);
+                            return None;
+                        }
+                    };
+                if json.is_some() {
+                    if let Err(e) = redis::cmd("DEL")
+                        .arg(&key)
+                        .query_async::<()>(&mut conn)
+                        .await
+                    {
+                        error!("Valkey DEL failed in remove: {}", e);
+                    }
+                }
+                json.and_then(|j| serde_json::from_str(&j).ok())
+            }
+        }
     }
 }
 
@@ -82,38 +293,42 @@ impl SessionManager {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_session_creation() {
-        let manager = SessionManager::new(Duration::from_secs(300));
-        let session =
-            manager.get_or_create("test123".to_string(), "https://example.com".to_string());
+    #[tokio::test]
+    async fn test_session_creation() {
+        let manager = SessionManager::new_memory(Duration::from_secs(300));
+        let session = manager
+            .get_or_create("test123".to_string(), "https://example.com".to_string())
+            .await;
 
         assert_eq!(session.session_id, "test123");
         assert_eq!(session.origin_url, "https://example.com");
-        assert_eq!(manager.session_count(), 1);
+        assert_eq!(manager.session_count().await, 1);
     }
 
-    #[test]
-    fn test_session_touch() {
-        let manager = SessionManager::new(Duration::from_secs(300));
-        let session =
-            manager.get_or_create("test456".to_string(), "https://example.com".to_string());
+    #[tokio::test]
+    async fn test_session_touch() {
+        let manager = SessionManager::new_memory(Duration::from_secs(300));
+        let session = manager
+            .get_or_create("test456".to_string(), "https://example.com".to_string())
+            .await;
 
         let initial_time = session.last_accessed;
         std::thread::sleep(Duration::from_millis(10));
-        manager.touch("test456");
+        manager.touch("test456").await;
 
-        let updated_session = manager.get("test456").unwrap();
+        let updated_session = manager.get("test456").await.unwrap();
         assert!(updated_session.last_accessed > initial_time);
     }
 
-    #[test]
-    fn test_session_removal() {
-        let manager = SessionManager::new(Duration::from_secs(300));
-        manager.get_or_create("test789".to_string(), "https://example.com".to_string());
+    #[tokio::test]
+    async fn test_session_removal() {
+        let manager = SessionManager::new_memory(Duration::from_secs(300));
+        manager
+            .get_or_create("test789".to_string(), "https://example.com".to_string())
+            .await;
 
-        assert_eq!(manager.session_count(), 1);
-        manager.remove("test789");
-        assert_eq!(manager.session_count(), 0);
+        assert_eq!(manager.session_count().await, 1);
+        manager.remove("test789").await;
+        assert_eq!(manager.session_count().await, 0);
     }
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3,7 +3,7 @@
 //! Starts a real Axum server on a random port and tests the full
 //! HTTP pipeline for both HLS and DASH endpoints.
 
-use ritcher::config::{AdProviderType, Config};
+use ritcher::config::{AdProviderType, Config, SessionStoreType};
 use ritcher::server::build_router;
 use std::net::SocketAddr;
 
@@ -20,9 +20,12 @@ async fn start_test_server() -> SocketAddr {
         vast_endpoint: None,
         slate_url: None,
         slate_segment_duration: 1.0,
+        session_store: SessionStoreType::Memory,
+        valkey_url: None,
+        session_ttl_secs: 300,
     };
 
-    let app = build_router(config);
+    let app = build_router(config).await;
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await


### PR DESCRIPTION
## Summary
- Optional Valkey/Redis-backed session store via \`valkey\` feature flag
- Enum dispatch (\`Backend::Memory\` / \`Backend::Valkey\`) — zero cost when feature is off
- All \`SessionManager\` methods converted to async
- Native Valkey TTL via \`SET ... EX\` — no manual cleanup needed
- Hard fail on startup if \`SESSION_STORE=valkey\` but Valkey is unreachable
- \`epoch_secs\` serde helper for \`SystemTime\` JSON serialization
- \`KEYS\` O(N) limitation documented with scale guidance

## Configuration
| Env var | Default | Description |
|---|---|---|
| \`SESSION_STORE\` | \`memory\` | \`memory\` or \`valkey\` |
| \`VALKEY_URL\` | — | Required when \`SESSION_STORE=valkey\` |
| \`SESSION_TTL_SECS\` | \`300\` | Session TTL in seconds |

## Test plan
- [x] All 92 tests pass (87 unit + 5 E2E)
- [x] \`cargo clippy -- -D warnings\` clean
- [x] \`cargo check --features valkey\` compiles
- [x] Memory backend behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)