### PR TITLE
fix: Dockerfile glibc mismatch and add .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,32 @@
+# Ritcher — Environment Variables
+# Copy this file to .env and adjust for your environment.
+
+# === Required in production (DEV_MODE=false) ===
+PORT=3000
+BASE_URL=https://ritcher.example.com
+ORIGIN_URL=https://cdn.example.com/live/playlist.m3u8
+
+# === Ad configuration ===
+# VAST endpoint URL (supports [DURATION] and [CACHEBUSTING] macros)
+# VAST_ENDPOINT=https://ads.example.com/vast?dur=[DURATION]&cb=[CACHEBUSTING]
+# AD_PROVIDER_TYPE=auto       # vast | static | auto (default: auto)
+# AD_SOURCE_URL=              # Static ad source URL (for static provider)
+# AD_SEGMENT_DURATION=1.0     # Ad segment duration in seconds
+
+# === Stitching mode ===
+# STITCHING_MODE=ssai          # ssai | sgai (default: ssai)
+
+# === Session store ===
+# SESSION_STORE=memory          # memory | valkey (default: memory)
+# VALKEY_URL=redis://localhost:6379  # Required if SESSION_STORE=valkey
+# SESSION_TTL_SECS=300          # Session expiration in seconds (default: 300)
+
+# === Slate fallback (for empty VAST responses) ===
+# SLATE_URL=https://cdn.example.com/slate/playlist.m3u8
+# SLATE_SEGMENT_DURATION=1.0
+
+# === Rate limiting ===
+# RATE_LIMIT_RPM=0              # Requests per minute per IP (0 = disabled)
+
+# === Development ===
+# DEV_MODE=true                 # Uses sensible defaults for missing required vars


### PR DESCRIPTION
## Summary
- Fix Dockerfile glibc version mismatch between builder (`rust:1.91-slim` = Debian 13) and runtime (`debian:bookworm-slim` = Debian 12) by using `rust:1.91-bookworm`
- Add dummy bench files in dependency cache layer (Cargo.toml `[[bench]]` targets require them)
- Copy `benches/` and `tests/` directories for complete build
- Add `.env.example` documenting all environment variables

## Test plan
- [x] `docker build -t ritcher:latest .` succeeds
- [x] `docker run -e DEV_MODE=true` + `curl /health` returns `{"status":"ok"}`
- [x] CI passes (fmt, clippy, test, build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)