### PR TITLE
fix: seamless content continuity and 10s ad breaks

### DIFF
--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -106,7 +106,7 @@ async fn demo_hls_playlist() {
     );
     let body = resp.text().await.unwrap();
     assert!(body.contains("#EXTM3U"));
-    assert!(body.contains("#EXT-X-CUE-OUT:30"));
+    assert!(body.contains("#EXT-X-CUE-OUT:10"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Change `BREAK_DURATION` from 30s to 10s to match DemoAdProvider (10 x 1s segments)
- Use placeholder segments in CUE-OUT zone (repeat last content segment index instead of advancing `seg_idx`), so content resumes seamlessly after ad breaks
- Update DASH manifest to not advance segment start numbers for break zones
- Update all tests to reflect new break duration and segment counts

Fixes the "content jumps forward after ad break" bug reported during demo testing.

## Test plan
- [ ] `cargo test` passes (all 214 tests)
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] Manually verify stitched playlist shows sequential content segments (url_462 → ad → url_463, no gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)