### PR TITLE
docs: fix architecture diagram with SSAI/SGAI flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,16 +52,21 @@ Ritcher runs as a standalone Docker container deployable anywhere. It integrates
 
 ```mermaid
 graph LR
-    Player -->|Request| S1
-    S1[Fetch manifest] --> S2[Detect ad breaks]
-    S2 --> S3[Fetch ads]
+    Player -->|Request| S1[Fetch manifest]
+    S1 --> S2[Detect ad breaks]
+    S2 --> Mode{SSAI / SGAI}
+    Mode -->|SSAI| S3[Fetch ads]
     S3 --> S4[Interleave segments]
-    S4 --> S5[Rewrite URLs]
-    S5 --> S6[Serve manifest]
+    Mode -->|SGAI| S5[Inject markers]
+    S4 --> S6[Rewrite URLs]
+    S5 --> S6
+    S6 --> S7[Serve manifest]
     CDN[Origin CDN] -.-> S1
     ADS[Ad Server] -.-> S3
     SLATE[Slate Source] -.-> S4
 ```
+
+> **SSAI** replaces content segments with ad segments server-side. **SGAI** injects HLS Interstitial `EXT-X-DATERANGE` tags or DASH callback `EventStream` elements — the player fetches ads client-side via the asset-list endpoint.
 
 ---
 


### PR DESCRIPTION
## Summary

- Architecture Mermaid diagram now shows both SSAI and SGAI paths branching after ad break detection
- Added explanatory note below the diagram

## Test plan

- [x] Documentation-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)